### PR TITLE
332164-Restrict-to-pass-serverdetails-to-client-app-Reactnodejs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The samples require the following to run.
  * [Node.js](https://nodejs.org/en/)
  * [Visual Studio Code](https://code.visualstudio.com/download)
 
-> **NOTE:** Node.js v14.16 to v18.16 are supported.
+> **NOTE:** Node.js v14.16 to v18.18 are supported.
 
 #### Help link
 

--- a/embed.js
+++ b/embed.js
@@ -57,15 +57,15 @@ function GetSignatureUrl(queryString)
 return gen_hmac;
 }
 app.get('/GetData', (req, res) => {
-  const embedConfigPath = path.join(__dirname, 'embedConfig.json');
-  const jsonData = fs.readFileSync(embedConfigPath, 'utf8');
+  const serverEmbedConfigData = path.join(__dirname, 'embedConfig.json');
+  const jsonData = fs.readFileSync(serverEmbedConfigData, 'utf8');
   const parsedData = JSON.parse(jsonData);
 
-  const configData = {
+  const clientEmbedConfigData = {
     DashboardId: parsedData.DashboardId, ServerUrl: parsedData.ServerUrl, SiteIdentifier: parsedData.SiteIdentifier, EmbedType: parsedData.EmbedType, Environment: parsedData.Environment
   };
 
-  res.send(configData);
+  res.send(clientEmbedConfigData);
 });
 
 app.listen(port, () => {

--- a/embed.js
+++ b/embed.js
@@ -59,7 +59,13 @@ return gen_hmac;
 app.get('/GetData', (req, res) => {
   const embedConfigPath = path.join(__dirname, 'embedConfig.json');
   const jsonData = fs.readFileSync(embedConfigPath, 'utf8');
-  res.send(jsonData);
+  const parsedData = JSON.parse(jsonData);
+
+  const configData = {
+    DashboardId: parsedData.DashboardId, ServerUrl: parsedData.ServerUrl, SiteIdentifier: parsedData.SiteIdentifier, EmbedType: parsedData.EmbedType, Environment: parsedData.Environment
+  };
+
+  res.send(configData);
 });
 
 app.listen(port, () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "embed.js",
   "dependencies": {
-    "@boldbi/boldbi-embedded-sdk": "6.6.12",
+    "@boldbi/boldbi-embedded-sdk": "^6.15.11",
     "cors": "^2.8.5",
     "express": "^4.18.2"
   },


### PR DESCRIPTION
The following Node.js versions have been verified and confirmed dashboard rendering fine.

Node.js v14.17.3
Node.js v16.16.0
Node.js v17.2.0
Node.js v18.18.2
Node.js v18.16.1